### PR TITLE
Trivial maintenance patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+png2snes

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,4 @@ test: tests.c $(SRC) $(HEADERS)
 	$(CC) $(CFLAGS) $(SRC) tests.c $(LDFLAGS) -o $@
 
 clean:
-	rm *.asm *.cgr *.vra
+	rm -f *.asm *.cgr *.vra

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
-CFLAGS=-std=c99 -Wall -pedantic -g -D_GNU_SOURCE
-LDFLAGS=-lpng -lz
+CFLAGS=-std=c99 -Wall -pedantic -g -D_GNU_SOURCE `libpng-config --cflags`
+LDFLAGS=`libpng-config --ldflags`
 HEADERS=argparser.h palette.h pngfunctions.h tile.h
 SRC=argparser.c palette.c pngfunctions.c tile.c
 TARGET=png2snes

--- a/main.c
+++ b/main.c
@@ -77,7 +77,7 @@ void generate_cgram(png_structp png_ptr, png_infop info_ptr, struct arguments ar
   else
     output_palette_wla(args.output_file, palette, palette_size);
 
-    free(palette);
+  free(palette);
 }
 
 void generate_vram(png_structp png_ptr, png_infop info_ptr, struct arguments args)

--- a/palette.c
+++ b/palette.c
@@ -1,5 +1,6 @@
 #include <png.h>
 #include <stdio.h>
+#include <string.h>
 #include <stdlib.h>
 
 #include "palette.h"

--- a/pngfunctions.c
+++ b/pngfunctions.c
@@ -43,7 +43,7 @@ int detect_png(FILE* fp)
 int initialize_libpng(FILE* fp, png_structp* png_ptr, png_infop* info_ptr, png_infop* end_info)
 {
   //Create the PNG Read Struct
-  *png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, png_voidp_NULL, NULL, NULL);
+  *png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
   if (!png_ptr)
   {
     fprintf(stderr, "Error creating libpng read struct\n");
@@ -55,7 +55,7 @@ int initialize_libpng(FILE* fp, png_structp* png_ptr, png_infop* info_ptr, png_i
 
   if (!info_ptr)
   {
-    png_destroy_read_struct(png_ptr, png_infopp_NULL, png_infopp_NULL);
+    png_destroy_read_struct(png_ptr, NULL, NULL);
     fprintf(stderr, "Error creating first info struct\n");
     return 0;
   }
@@ -64,7 +64,7 @@ int initialize_libpng(FILE* fp, png_structp* png_ptr, png_infop* info_ptr, png_i
   *end_info = png_create_info_struct(*png_ptr);
   if (!end_info)
   {
-    png_destroy_read_struct(png_ptr, info_ptr, png_infopp_NULL);
+    png_destroy_read_struct(png_ptr, info_ptr, NULL);
     fprintf(stderr, "Error creating second info struct\n");
     return 0;
   }


### PR DESCRIPTION
png2snes would not compile as-is on my Debian due to the use of deprecated libpng typedefs. While I was at it I also fixed a few warnings that newer compilers issue and made other minor changes.