### PR TITLE
Palette generation improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC=gcc
 CFLAGS=-std=c99 -Wall -pedantic -g -D_GNU_SOURCE `libpng-config --cflags`
-LDFLAGS=`libpng-config --ldflags`
+LDFLAGS=`libpng-config --ldflags` -lm
 HEADERS=argparser.h palette.h pngfunctions.h tile.h
 SRC=argparser.c palette.c pngfunctions.c tile.c
 TARGET=png2snes

--- a/main.c
+++ b/main.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <math.h>
 
 #include "argparser.h"
 #include "palette.h"
@@ -64,7 +65,7 @@ void generate_cgram(png_structp png_ptr, png_infop info_ptr, struct arguments ar
 {
   //Convert palette to the format used by the SNES
   int palette_size;
-  uint16_t* palette = convert_palette(png_ptr, info_ptr, &palette_size);
+  uint16_t* palette = convert_palette(png_ptr, info_ptr, &palette_size, powl(2, args.bitplanes));
 
   if(args.verbose)
   {

--- a/main.c
+++ b/main.c
@@ -11,7 +11,7 @@
 
 #define DEFAULT_TILE_SIZE 8
 
-void generate_cgram(png_structp png_ptr, png_infop info_ptr, struct arguments args);
+int generate_cgram(png_structp png_ptr, png_infop info_ptr, struct arguments args);
 void generate_vram(png_structp png_ptr, png_infop info_ptr, struct arguments args);
 uint8_t* convert_to_tiles(uint8_t* data, unsigned int width, unsigned int height, unsigned int bitplane_count, unsigned int tilesize, unsigned int* data_size);
 
@@ -48,7 +48,9 @@ int main(int argc, char *argv[])
   if(!detect_palette(png_ptr, info_ptr))
     goto clean_png_struct;
 
-  generate_cgram(png_ptr, info_ptr, args);
+  if (generate_cgram(png_ptr, info_ptr, args) != 0)
+    goto clean_png_struct;
+
   generate_vram(png_ptr, info_ptr, args);
 
   exit_code++;
@@ -61,11 +63,14 @@ close_file:
   return exit_code;
 }
 
-void generate_cgram(png_structp png_ptr, png_infop info_ptr, struct arguments args)
+int generate_cgram(png_structp png_ptr, png_infop info_ptr, struct arguments args)
 {
   //Convert palette to the format used by the SNES
   int palette_size;
   uint16_t* palette = convert_palette(png_ptr, info_ptr, &palette_size, powl(2, args.bitplanes));
+
+  if (!palette)
+	  return -1;
 
   if(args.verbose)
   {
@@ -79,6 +84,8 @@ void generate_cgram(png_structp png_ptr, png_infop info_ptr, struct arguments ar
     output_palette_wla(args.output_file, palette, palette_size);
 
   free(palette);
+
+  return 0;
 }
 
 void generate_vram(png_structp png_ptr, png_infop info_ptr, struct arguments args)

--- a/palette.c
+++ b/palette.c
@@ -7,20 +7,34 @@
 
 #define CONVERT_TO_BGR15(red, green, blue) (((blue & 0xF8) << 7) | ((green & 0xF8) << 2) | (red >> 3))
 
-uint16_t* convert_palette(png_structp png_ptr, png_infop info_ptr, int* size)
+uint16_t* convert_palette(png_structp png_ptr, png_infop info_ptr, int* size, int pad_to_size)
 {
   uint16_t* palette;
   png_color* png_palette;
+  int src_size, final_size;
 
   //Fetch Palette from PNG file
-  png_get_PLTE(png_ptr, info_ptr, &png_palette, size);
+  png_get_PLTE(png_ptr, info_ptr, &png_palette, &src_size);
 
-  //Allocate memory for palette
-  palette = malloc(*size * sizeof(uint16_t));
-  for(size_t i = 0; i < *size; i++)
+  if (pad_to_size > 0) {
+    if (pad_to_size < src_size) {
+      fprintf(stderr, "More colors (%d) than expected (%d)\n", src_size, pad_to_size);
+      return NULL;
+    }
+    final_size = pad_to_size;
+  } else {
+    final_size = src_size;
+  }
+
+  //Allocate memory for palette. Potentially has more entires than
+  //the source PNG when pad_to_size is used. Unused entries will be zeroed
+  //by calloc.
+  palette = calloc(final_size,sizeof(uint16_t));
+
+  for(size_t i = 0; i < src_size; i++)
     palette[i] = CONVERT_TO_BGR15(png_palette[i].red, png_palette[i].green, png_palette[i].blue);
 
-  for(size_t i = 1; i < *size; i++)
+  for(size_t i = 1; i < src_size; i++)
   {
     for(size_t j = 1; j < i; j++)
     {
@@ -28,6 +42,8 @@ uint16_t* convert_palette(png_structp png_ptr, png_infop info_ptr, int* size)
         fprintf(stderr, "Found duplicate colors %lu and %lu\n", i, j);
     }
   }
+
+  *size = final_size;
 
   return palette;
 }

--- a/palette.h
+++ b/palette.h
@@ -2,7 +2,7 @@
 #define PALETTE_H
 #include <stdint.h>
 
-uint16_t* convert_palette(png_structp png_ptr, png_infop info_ptr, int* size);
+uint16_t* convert_palette(png_structp png_ptr, png_infop info_ptr, int* size, int pad_to_size);
 void output_palette_binary(char* basename, uint16_t* data, int words);
 void output_palette_wla(char* basename, uint16_t* data, int words);
 


### PR DESCRIPTION
Everything is explained in details in the individual commits, but the summary is:

1- Pad the palette size to match bit depth

For instance, when converting a png for use in 4bpp (16 color) mode, the
generated palette data should contain 16 entries. (otherwise it breaks alignment when including several palettes one after another in assembly)

2- Abort if there are too many colors
This change catches the problem opposite the above.When the source palette contains too many colors, abort.